### PR TITLE
Fix(api): Correct Google Photos API authentication flow

### DIFF
--- a/photosApi.js
+++ b/photosApi.js
@@ -76,22 +76,13 @@ async function ensureToken({forceFresh=false} = {}) {
   const stillValid = token && Date.now() < tokenExp;
   if (stillValid && !forceFresh) return token;
 
-  // Force un nouveau token et un re-consent explicite
-  await signIn({ forceConsent: true });
+  // Demande un nouveau token (et potentiellement un re-consent)
+  await signIn({ forceConsent: false }); // <- `false` est la valeur par défaut
   return token;
 }
 
 async function gFetch(url, opts = {}) {
-  // <- forceFresh: true le temps du diagnostic
-  const t = await ensureToken({ forceFresh: true });
-
-  // DIAGNOSTIC: montre les scopes du token utilisé pour CET appel
-  try {
-    const info = await fetch('https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=' + t).then(r => r.json());
-    console.log('[Photosflix] TOKEN USED SCOPES:', info.scope);
-  } catch (e) {
-    console.warn('[Photosflix] tokeninfo check failed:', e);
-  }
+  const t = await ensureToken();
 
   const res = await fetch(url, {
     ...opts,


### PR DESCRIPTION
The Google Photos API integration was failing due to an incorrect authentication flow. This was caused by diagnostic code that was left in the `gFetch` function, which was making an unnecessary and failing call to the `tokeninfo` endpoint.

This commit removes the diagnostic code from `gFetch` and also removes the `forceConsent: true` parameter from the `ensureToken` function. This allows the authentication flow to work as expected and re-enables token reuse.